### PR TITLE
Use polling approach to trigger comms to other robots

### DIFF
--- a/interface_rajant/launch/rajant_nodes.launch.py
+++ b/interface_rajant/launch/rajant_nodes.launch.py
@@ -40,22 +40,10 @@ def generate_launch_description():
     radio_configs = LaunchConfiguration('radio_configs')
 
     # Define nodes
-    rajant_query_node = Node(
+    rajant_peer_rssi = Node(
         package='interface_rajant',
-        executable='rajant_query.py',
-        name='rajant_query',
-        output='screen',
-        parameters=[{
-            'robot_name': robot_name,
-            'robot_configs': robot_configs,
-            'radio_configs': radio_configs
-        }]
-    )
-
-    rajant_parser_node = Node(
-        package='interface_rajant',
-        executable='rajant_parser.py',
-        name='rajant_parser',
+        executable='rajant_peer_rssi.py',
+        name='rajant_peer_rssi',
         output='screen',
         parameters=[{
             'robot_name': robot_name,
@@ -68,6 +56,5 @@ def generate_launch_description():
         robot_name_arg,
         robot_configs_arg,
         radio_configs_arg,
-        rajant_query_node,
-        rajant_parser_node
+        rajant_peer_rssi
     ])

--- a/interface_rajant/launch/rajant_nodes.launch.py
+++ b/interface_rajant/launch/rajant_nodes.launch.py
@@ -34,10 +34,20 @@ def generate_launch_description():
         description='Path to radio configuration file'
     )
 
+    bcapi_jar_file_arg = DeclareLaunchArgument(
+        'bcapi_jar_file',
+        default_value=PathJoinSubstitution([
+            FindPackageShare('interface_rajant'),
+            'thirdParty', 'PeerRSSI-bcapi-11.26.1.jar'
+        ]),
+        description='Path to jar file used to get rssi'
+    )
+
     # Get launch configurations
     robot_name = LaunchConfiguration('robot_name')
     robot_configs = LaunchConfiguration('robot_configs')
     radio_configs = LaunchConfiguration('radio_configs')
+    bcapi_jar_file = LaunchConfiguration('bcapi_jar_file')
 
     # Define nodes
     rajant_peer_rssi = Node(
@@ -48,7 +58,8 @@ def generate_launch_description():
         parameters=[{
             'robot_name': robot_name,
             'robot_configs': robot_configs,
-            'radio_configs': radio_configs
+            'radio_configs': radio_configs,
+            'bcapi_jar_file': bcapi_jar_file
         }]
     )
 
@@ -56,5 +67,6 @@ def generate_launch_description():
         robot_name_arg,
         robot_configs_arg,
         radio_configs_arg,
-        rajant_peer_rssi
+        bcapi_jar_file_arg,
+        rajant_peer_rssi,
     ])


### PR DESCRIPTION
This PR changes the approach for triggering communications between robots:
 - **Before** we used watchers (watchstate), which was a passive system that triggered callbacks when the internal state of a robot was modified. This has the disadvantage that robots that are stationary wrt each other may not trigger comms.
 - **Now** we use a polled system that triggers comms regularly.
 
 Fixes #10 