### PR TITLE
Remove numpy from database.py

### DIFF
--- a/mocha_core/mocha_core/database.py
+++ b/mocha_core/mocha_core/database.py
@@ -3,9 +3,6 @@ import threading
 import mocha_core.hash_comm as hash_comm
 import rclpy.time
 import pdb
-import mocha_core.database_utils as du
-import numpy as np
-import copy
 
 
 class DBMessage():


### PR DESCRIPTION
This completely removes numpy during runtime. Only remaining reference is in `hash_comm.py` when testing collisions.  